### PR TITLE
Checkpatch fixes for test

### DIFF
--- a/tools/testing/selftests/bus1/test.c
+++ b/tools/testing/selftests/bus1/test.c
@@ -27,8 +27,8 @@
 #define N_TESTS (sizeof(tests) / sizeof(tests[0]))
 
 static const char *arg_module = "bus1";
-static const char *arg_test = NULL;
-char *test_path = NULL;
+static const char *arg_test;
+char *test_path;
 
 int c_sys_clone(unsigned long flags, void *child_stack)
 {

--- a/tools/testing/selftests/bus1/test.c
+++ b/tools/testing/selftests/bus1/test.c
@@ -71,7 +71,7 @@ static int run_one(const struct test *test)
 	fprintf(stdout, "Testing: `%s' ", test->name);
 	for (i = line_len; i < 60; ++i)
 		fprintf(stdout, ".");
-	fprintf(stdout, " \n\n");
+	fprintf(stdout, "\n\n");
 	fflush(stdout);
 
 	/* run test */


### PR DESCRIPTION
Fixes two errors and one warning. Also wanted to fix the following ones:

> tools/testing/selftests/bus1/test.c:27: WARNING: Prefer ARRAY_SIZE(tests)
> tools/testing/selftests/bus1/test.c:149: WARNING: quoted string split across lines

but I am not sure what is the appropriate way to.
