### PR TITLE
Fix typos for comments in message, peer and transaction

### DIFF
--- a/ipc/bus1/message.c
+++ b/ipc/bus1/message.c
@@ -143,7 +143,7 @@ struct bus1_message *bus1_message_unref(struct bus1_message *message)
  * given user for all the associated in-flight resources.
  *
  * This returns the message resources pinned. Use bus1_message_unpin() to
- * realease them again.
+ * release them again.
  *
  * Return: 0 on success, negative error code on failure.
  */

--- a/ipc/bus1/peer.c
+++ b/ipc/bus1/peer.c
@@ -253,7 +253,7 @@ static void bus1_peer_cleanup(struct bus1_active *active, void *userdata)
 	/*
 	 * bus1_active guarantees that this function is called exactly once,
 	 * and that it cannot race bus1_peer_connect(). It is therefore safe
-	 * to access the info obect without any locking.
+	 * to access the info object without any locking.
 	 */
 	peer_info = rcu_dereference_raw(peer->info);
 	rcu_assign_pointer(peer->info, NULL);

--- a/ipc/bus1/transaction.c
+++ b/ipc/bus1/transaction.c
@@ -282,7 +282,7 @@ error:
  *
  * This releases a transaction and all associated memory. If the transaction
  * failed, any in-flight messages are dropped and pinned peers are released. If
- * the transaction was successfull, this just releases the temporary data that
+ * the transaction was successful, this just releases the temporary data that
  * was used for the transmission.
  *
  * If NULL is passed, this is a no-op.
@@ -561,7 +561,7 @@ int bus1_transaction_commit(struct bus1_transaction *transaction)
 	 * message cannot be dequeued and blocks (until the message is finally
 	 * committed) any future messages on each queue from being dequeued too.
 	 * However, no messages that were finally committed before this message
-	 * was staged are blocked. At the end of the loop, it is guananteed that
+	 * was staged are blocked. At the end of the loop, it is guaranteed that
 	 * all messages after @timestamp are blocked on all destination queues.
 	 */
 	for (message = list; message; message = message->transaction.next) {


### PR DESCRIPTION
- s/realease/release
- s/obect/object
- s/successfull/successful
- s/guananteed/guaranteed
