### PR TITLE
Checkpatch fix selftest

### DIFF
--- a/tools/testing/selftests/bus1/bus1-ioctl.h
+++ b/tools/testing/selftests/bus1/bus1-ioctl.h
@@ -22,7 +22,7 @@ extern "C" {
 static inline int
 bus1_ioctl(int fd, unsigned int cmd, void *arg)
 {
-	return (ioctl(fd, cmd, arg) >= 0) ? 0: -errno;
+	return (ioctl(fd, cmd, arg) >= 0) ? 0 : -errno;
 }
 
 static inline int


### PR DESCRIPTION
Fixes the following checkpatch output:

ERROR: spaces required around that ':' (ctx:VxW)

Introduced in 02f5769a990c (bus1: merge the bus2-branch into master,
2016-10-26)
