### PR TITLE
Fix sparse warning

### DIFF
--- a/ipc/bus1/tests.c
+++ b/ipc/bus1/tests.c
@@ -133,7 +133,7 @@ static void bus1_test_pool(void)
 	struct bus1_pool_slice *slice;
 	char *payload = "PAYLOAD";
 	struct iovec vec = {
-		.iov_base = payload,
+		.iov_base = (void __user *)payload,
 		.iov_len = strlen(payload),
 	};
 	struct kvec kvec = {


### PR DESCRIPTION
Found only one warning running sparse (0.5.0):

```
warning: incorrect type in initializer (different address spaces)
   expected void [noderef] <asn:1>*iov_base
   got char *payload
```