### PR TITLE
Ensure msg.destination refers to a peer local handle id

### DIFF
--- a/ipc/bus1/peer.c
+++ b/ipc/bus1/peer.c
@@ -724,7 +724,7 @@ static struct bus1_message *bus1_peer_new_message(struct bus1_peer *peer,
 						  u64 id)
 {
 	struct bus1_message *m = NULL;
-	struct bus1_handle *h = NULL;
+	struct bus1_handle *h = NULL, *dst_h = NULL;
 	struct bus1_peer *p = NULL;
 	bool is_new;
 	int r;
@@ -740,8 +740,13 @@ static struct bus1_message *bus1_peer_new_message(struct bus1_peer *peer,
 
 	if (bus1_handle_is_anchor(h))
 		p = bus1_peer_acquire(peer);
-	else
+	else {
 		p = bus1_handle_acquire_owner(h);
+		bus1_handle_ref(h->anchor);
+		dst_h = h->anchor;
+		bus1_handle_unref(h);
+		h = dst_h;
+	}
 	if (!p) {
 		r = -ESHUTDOWN;
 		goto error;


### PR DESCRIPTION
The struct bus1_cmd_recv.msg describing a message received on a peer using the BUS1_CMD_RECV command includes a destination which is a handle ID referring to the node a message was sent to.

In the current implementation the handle value given to the receiving peer is the one used by the sending peer to initially send the message.

As handle values are peer local, this ID has no meaning for the receiving peer and can not be used to find which node the message was sent to.

This PR:
* fixes the remote handle ID logic in bus1_peer_new_message to make sure that remote handles will be converted to peer local handle ID values.
* adds a test for this issue.

I have tried to test this change but I am definitely not certain about the bus1_handle_ref(h->anchor) / bus1_handle_unref(h) part.

Please tell me if you would rather have me post those changes on LKML.

I'm also writing a wrapper in Rust for bus1. The current state of the code is at: https://github.com/bus1-rust/bus1-rs

Thanks