### PR TITLE
bus1: replace GFP_TEMPORARY with GFP_KERNEL

### DIFF
--- a/ipc/bus1/message.c
+++ b/ipc/bus1/message.c
@@ -85,7 +85,7 @@ struct bus1_factory *bus1_factory_new(struct bus1_peer *peer,
 
 	size = bus1_factory_size(param);
 	if (unlikely(size > n_stack)) {
-		f = kmalloc(size, GFP_TEMPORARY);
+		f = kmalloc(size, GFP_KERNEL);
 		if (!f)
 			return ERR_PTR(-ENOMEM);
 
@@ -115,7 +115,7 @@ struct bus1_factory *bus1_factory_new(struct bus1_peer *peer,
 		goto error;
 
 	/* import handles */
-	r = bus1_flist_populate(f->handles, f->param->n_handles, GFP_TEMPORARY);
+	r = bus1_flist_populate(f->handles, f->param->n_handles, GFP_KERNEL);
 	if (r < 0)
 		goto error;
 
@@ -501,7 +501,7 @@ int bus1_message_install(struct bus1_message *m, bool inst_fds)
 	size = max(m->n_files, min_t(size_t, m->n_handles, BUS1_FLIST_BATCH));
 	size *= max(sizeof(*fds), sizeof(*handles));
 	if (unlikely(size > sizeof(stack))) {
-		buffer = kmalloc(size, GFP_TEMPORARY);
+		buffer = kmalloc(size, GFP_KERNEL);
 		if (!buffer)
 			return -ENOMEM;
 	}

--- a/ipc/bus1/tests.c
+++ b/ipc/bus1/tests.c
@@ -41,14 +41,14 @@ static void bus1_test_flist(void)
 	size_t i, j, z, n;
 
 	WARN_ON(bus1_flist_free(NULL, 0));
-	WARN_ON(bus1_flist_new(0, GFP_TEMPORARY));
+	WARN_ON(bus1_flist_new(0, GFP_KERNEL));
 
 	/*
 	 * Allocate small list, initialize all entries via normal iteration,
 	 * then validate them via batch iteration.
 	 */
 	n = 8;
-	list = bus1_flist_new(n, GFP_TEMPORARY);
+	list = bus1_flist_new(n, GFP_KERNEL);
 	WARN_ON(!list);
 
 	for (i = 0, e = list; i < n; e = bus1_flist_next(e, &i))
@@ -68,7 +68,7 @@ static void bus1_test_flist(void)
 	 * size of flists.
 	 */
 	n = BUS1_FLIST_BATCH * 8;
-	list = bus1_flist_new(n, GFP_TEMPORARY);
+	list = bus1_flist_new(n, GFP_KERNEL);
 	WARN_ON(!list);
 
 	for (i = 0, e = list; i < n; e = bus1_flist_next(e, &i))


### PR DESCRIPTION
The kernel has long rid itself of GFP_TEMPORARY, which was equivalent to `GFP_KERNEL | __GFP_RECLAIMABLE`. I'm *hoping* I got the commit format right. This was the first thing I ran into trying to build on newer kernels, there's more that needs to be patched up before that works.