### PR TITLE
handle minor API changes up to kernel 4.14

### DIFF
--- a/ipc/bus1/message.c
+++ b/ipc/bus1/message.c
@@ -85,7 +85,7 @@ struct bus1_factory *bus1_factory_new(struct bus1_peer *peer,
 
 	size = bus1_factory_size(param);
 	if (unlikely(size > n_stack)) {
-		f = kmalloc(size, GFP_TEMPORARY);
+		f = kmalloc(size, GFP_KERNEL);
 		if (!f)
 			return ERR_PTR(-ENOMEM);
 
@@ -115,7 +115,7 @@ struct bus1_factory *bus1_factory_new(struct bus1_peer *peer,
 		goto error;
 
 	/* import handles */
-	r = bus1_flist_populate(f->handles, f->param->n_handles, GFP_TEMPORARY);
+	r = bus1_flist_populate(f->handles, f->param->n_handles, GFP_KERNEL);
 	if (r < 0)
 		goto error;
 
@@ -501,7 +501,7 @@ int bus1_message_install(struct bus1_message *m, bool inst_fds)
 	size = max(m->n_files, min_t(size_t, m->n_handles, BUS1_FLIST_BATCH));
 	size *= max(sizeof(*fds), sizeof(*handles));
 	if (unlikely(size > sizeof(stack))) {
-		buffer = kmalloc(size, GFP_TEMPORARY);
+		buffer = kmalloc(size, GFP_KERNEL);
 		if (!buffer)
 			return -ENOMEM;
 	}

--- a/ipc/bus1/tests.c
+++ b/ipc/bus1/tests.c
@@ -41,14 +41,14 @@ static void bus1_test_flist(void)
 	size_t i, j, z, n;
 
 	WARN_ON(bus1_flist_free(NULL, 0));
-	WARN_ON(bus1_flist_new(0, GFP_TEMPORARY));
+	WARN_ON(bus1_flist_new(0, GFP_KERNEL));
 
 	/*
 	 * Allocate small list, initialize all entries via normal iteration,
 	 * then validate them via batch iteration.
 	 */
 	n = 8;
-	list = bus1_flist_new(n, GFP_TEMPORARY);
+	list = bus1_flist_new(n, GFP_KERNEL);
 	WARN_ON(!list);
 
 	for (i = 0, e = list; i < n; e = bus1_flist_next(e, &i))
@@ -68,7 +68,7 @@ static void bus1_test_flist(void)
 	 * size of flists.
 	 */
 	n = BUS1_FLIST_BATCH * 8;
-	list = bus1_flist_new(n, GFP_TEMPORARY);
+	list = bus1_flist_new(n, GFP_KERNEL);
 	WARN_ON(!list);
 
 	for (i = 0, e = list; i < n; e = bus1_flist_next(e, &i))

--- a/ipc/bus1/util/pool.c
+++ b/ipc/bus1/util/pool.c
@@ -23,6 +23,7 @@
 #include <linux/slab.h>
 #include <linux/uaccess.h>
 #include <linux/uio.h>
+#include <linux/version.h>
 #include "pool.h"
 
 /* insert slice into the free tree */
@@ -459,7 +460,11 @@ ssize_t bus1_pool_write_iovec(struct bus1_pool *pool,
 	offset += slice->offset;
 	iov_iter_init(&iter, WRITE, iov, n_iov, total_len);
 
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 12, 0)
+	len = vfs_iter_write(pool->f, &iter, &offset, 0);
+#else
 	len = vfs_iter_write(pool->f, &iter, &offset);
+#endif
 
 	return (len >= 0 && len != total_len) ? -EFAULT : len;
 }
@@ -501,7 +506,11 @@ ssize_t bus1_pool_write_kvec(struct bus1_pool *pool,
 
 	old_fs = get_fs();
 	set_fs(get_ds());
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 12, 0)
+	len = vfs_iter_write(pool->f, &iter, &offset, 0);
+#else
 	len = vfs_iter_write(pool->f, &iter, &offset);
+#endif
 	set_fs(old_fs);
 
 	return (len >= 0 && len != total_len) ? -EFAULT : len;


### PR DESCRIPTION
This replaces `GFP_TEMPORARY` with `GFP_KERNEL` unconditionally, and handles the flags argument for `vfs_iter_write` conditional on kernel version. I hope I got the commit format right.