### PR TITLE
handle: convert lockless_dereference() to READ_ONCE()

### DIFF
--- a/ipc/bus1/handle.c
+++ b/ipc/bus1/handle.c
@@ -138,7 +138,7 @@ static struct bus1_peer *bus1_handle_acquire_holder(struct bus1_handle *handle)
 	 */
 	rcu_read_lock();
 	if (atomic_read_acquire(&handle->n_weak) > 0)
-		peer = bus1_peer_acquire(lockless_dereference(handle->holder));
+		peer = bus1_peer_acquire(READ_ONCE(handle->holder));
 	rcu_read_unlock();
 
 	return peer;


### PR DESCRIPTION
This is the fix for compilation failure due to removal of
lockless_dereference() in 4.15. In-tree users of lockless_dereference()
were migrated to READ_ONCE().

See: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?h=v4.16&id=506458efaf15