### PR TITLE
util: fix calls of access_ok macro

### DIFF
--- a/ipc/bus1/util.c
+++ b/ipc/bus1/util.c
@@ -78,8 +78,7 @@ int bus1_import_vecs(struct iovec *out_vecs,
 #endif
 		void __user *v_ptr;
 
-		if (unlikely(!access_ok(VERIFY_READ, vecs,
-					sizeof(*uvecs) * n_vecs)))
+		if (unlikely(!access_ok(vecs, sizeof(*uvecs) * n_vecs)))
 			return -EFAULT;
 
 		for (i = 0; i < n_vecs; ++i) {
@@ -97,7 +96,7 @@ int bus1_import_vecs(struct iovec *out_vecs,
 			if (unlikely(v_slen < 0 ||
 				     (typeof(v_len))v_slen != v_len))
 				return -EMSGSIZE;
-			if (unlikely(!access_ok(VERIFY_READ, v_ptr, v_len)))
+			if (unlikely(!access_ok(v_ptr, v_len)))
 				return -EFAULT;
 			if (unlikely((size_t)v_len > MAX_RW_COUNT - length))
 				return -EMSGSIZE;
@@ -119,7 +118,7 @@ int bus1_import_vecs(struct iovec *out_vecs,
 
 			if (unlikely((ssize_t)v_len < 0))
 				return -EMSGSIZE;
-			if (unlikely(!access_ok(VERIFY_READ, v_base, v_len)))
+			if (unlikely(!access_ok(v_base, v_len)))
 				return -EFAULT;
 			if (unlikely(v_len > MAX_RW_COUNT - length))
 				return -EMSGSIZE;


### PR DESCRIPTION
v5.0-rc1 [1] dropped the first parameter of the access_ok macro. Fix compilation errors in ipc/bus1/util.c caused by this change.

[1] - https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=96d4f267e40f9509e8a66e2b39e8b95655617693