### PR TITLE
get rid of legacy 'get_ds()' function

### DIFF
--- a/ipc/bus1/tests.c
+++ b/ipc/bus1/tests.c
@@ -165,7 +165,7 @@ static void bus1_test_pool(void)
 	WARN_ON(r < 0);
 
 	old_fs = get_fs();
-	set_fs(get_ds());
+	set_fs(KERNEL_DS);
 	r = bus1_pool_write_iovec(&pool, &slice, 0, &vec, 1, vec.iov_len);
 	WARN_ON(r < 0);
 	set_fs(old_fs);

--- a/ipc/bus1/util/pool.c
+++ b/ipc/bus1/util/pool.c
@@ -500,7 +500,7 @@ ssize_t bus1_pool_write_kvec(struct bus1_pool *pool,
 	iov_iter_kvec(&iter, WRITE | ITER_KVEC, iov, n_iov, total_len);
 
 	old_fs = get_fs();
-	set_fs(get_ds());
+	set_fs(KERNEL_DS);
 	len = vfs_iter_write(pool->f, &iter, &offset, 0);
 	set_fs(old_fs);
 


### PR DESCRIPTION

According to 736706bee329 ("get rid of legacy'get_ds()' function")
get_ds() has been deleted, so we also need to adjust the code in the
driver accordingly.